### PR TITLE
Input should have <p>

### DIFF
--- a/packages/components/src/Input/Input.js
+++ b/packages/components/src/Input/Input.js
@@ -689,6 +689,33 @@ class Input extends EditorBase {
     }
 
     const { inputLabelRootDisabled, inputLabelRoot } = classes;
+    let formHelperText;
+
+    if (!this.props.inlineGridMode && error) {
+      formHelperText = (
+        <div style={errorStyle}>
+          <MuiFormHelperText style={{ marginTop: 0 }} disabled={this.state.disabled}>
+            {errorText}
+          </MuiFormHelperText>
+        </div>
+      );
+    } else if (!this.props.inlineGridMode && (bottomLeftInfoSpace || bottomRightInfoSpace)) {
+      formHelperText = (
+        <div style={bottomInfoStyle}>
+          <MuiFormHelperText style={{ marginTop: 0 }} disabled={this.state.disabled}>
+            {bottomLeftInfoSpace}
+            {bottomRightInfoSpace}
+          </MuiFormHelperText>
+        </div>
+      );
+    } else {
+      formHelperText = (
+        <MuiFormHelperText
+          style={{ marginTop: 0 }}
+          disabled={this.state.disabled} />
+      );
+    }
+
     return (
       <div style={rootStyle}>
         <MuiFormControl
@@ -769,21 +796,7 @@ class Input extends EditorBase {
               )
             }
           />
-          {!this.props.inlineGridMode && error && (
-            <div style={errorStyle}>
-              <MuiFormHelperText style={{ marginTop: 0 }} disabled={this.state.disabled}>
-                {errorText}
-              </MuiFormHelperText>
-            </div>
-          )}
-          {!this.props.inlineGridMode && (bottomLeftInfoSpace || bottomRightInfoSpace) && (
-            <div style={bottomInfoStyle}>
-              <MuiFormHelperText style={{ marginTop: 0 }} disabled={this.state.disabled}>
-                {bottomLeftInfoSpace}
-                {bottomRightInfoSpace}
-              </MuiFormHelperText>
-            </div>
-          )}
+          {formHelperText}
         </MuiFormControl>
       </div>
     );

--- a/packages/components/src/Input/Input.test.js
+++ b/packages/components/src/Input/Input.test.js
@@ -321,8 +321,8 @@ describe('<Input />', () => {
 
     it('should not render bottomLeftInfo when error exists', () => {
       const wrapper = mount(<Input context={context} bottomLeftInfo="test" errorText="error" />);
-      const span = wrapper.find('span').first();
-      assert.strictEqual(span.props().style.display, 'none');
+      const span = wrapper.find('span');
+      assert.strictEqual(span.exists(), false);
     });
 
     it('should render bottomLeftInfo RTL', () => {

--- a/packages/components/src/TreeView/TreeView.test.js
+++ b/packages/components/src/TreeView/TreeView.test.js
@@ -55,7 +55,7 @@ describe('<TreeView />', () => {
       });
       wrapper.instance().filteringContainer.search();
       getValueStub.restore();
-      assert.strictEqual(wrapper.find('p').text(), '2 BOA.TreeviewItemFound');
+      assert.strictEqual(wrapper.find('p').at(1).text(), '2 BOA.TreeviewItemFound');
     });
 
     it('should search with click', () => {
@@ -68,7 +68,7 @@ describe('<TreeView />', () => {
       });
       button.simulate('click');
       getValueStub.restore();
-      assert.strictEqual(wrapper.find('p').text(), '2 BOA.TreeviewItemFound');
+      assert.strictEqual(wrapper.find('p').at(1).text(), '2 BOA.TreeviewItemFound');
     });
 
     it('should search async with key down', () => {
@@ -82,7 +82,7 @@ describe('<TreeView />', () => {
       input.find('input').simulate('keyDown', { keyCode: 40 });
       clock.tick(1000);
       getValueStub.restore();
-      assert.strictEqual(wrapper.find('p').text(), '2 BOA.TreeviewItemFound');
+      assert.strictEqual(wrapper.find('p').at(1).text(), '2 BOA.TreeviewItemFound');
     });
 
     it('should search with enter key down immediately', () => {
@@ -94,7 +94,7 @@ describe('<TreeView />', () => {
       });
       input.find('input').simulate('keyDown', { keyCode: 13 });
       getValueStub.restore();
-      assert.strictEqual(wrapper.find('p').text(), '2 BOA.TreeviewItemFound');
+      assert.strictEqual(wrapper.find('p').at(1).text(), '2 BOA.TreeviewItemFound');
     });
 
     it('should clear search', () => {
@@ -109,7 +109,7 @@ describe('<TreeView />', () => {
       getValueStub.restore();
       const button = wrapper.find('button').last();
       button.simulate('click');
-      assert.strictEqual(wrapper.find('p').text(), '1 BOA.TreeviewItemSelected');
+      assert.strictEqual(wrapper.find('p').at(1).text(), '1 BOA.TreeviewItemSelected');
     });
   });
 


### PR DESCRIPTION
In the legacy code Input has a block like below and it renders ```<p><div></div></p>```

```jsx
          {!this.props.inlineGridMode && (
            <FormHelperText 
              style={{ marginTop: 0 }}
              disabled={this.state.disabled}>
              {error && <div style={errorStyle}>{errorText}</div>}
              {bottomLeftInfoSpace || bottomRightInfoSpace ? (
                <div style={bottomInfoStyle}>
                  {bottomLeftInfoSpace}
                  {bottomRightInfoSpace}
                </div>
              ) : null}
            </FormHelperText>
          )}
```
```<p><div></div></p>``` is not valid HTML, so I replaced it.

```jsx
          {!this.props.inlineGridMode && error && (
            <div style={errorStyle}>
              <MuiFormHelperText style={{ marginTop: 0 }} disabled={this.state.disabled}>
                {errorText}
              </MuiFormHelperText>
            </div>
          )}
          {!this.props.inlineGridMode && (bottomLeftInfoSpace || bottomRightInfoSpace) && (
            <div style={bottomInfoStyle}>
              <MuiFormHelperText style={{ marginTop: 0 }} disabled={this.state.disabled}>
                {bottomLeftInfoSpace}
                {bottomRightInfoSpace}
              </MuiFormHelperText>
            </div>
          )}
```
Now, this code works but an Input should have FormHelperText always. Is it right? @canpolatoral 
This PR adds a `FormHelperText` by default. 
