### PR TITLE
BDateTimePicker fixed.

### DIFF
--- a/packages/components/src/DateTimePicker/DatePicker.js
+++ b/packages/components/src/DateTimePicker/DatePicker.js
@@ -301,7 +301,7 @@ class DatePicker extends ComponentBase {
       return (
         <div
           style={{
-            width: timeFormat ? '65%' : '100%',
+            width: (!timeFormat && this.props.fullWidth) ? '100%' : '65%',
           }}
           ref={r => (this.rootDate = r)}
         >
@@ -416,7 +416,7 @@ class DatePicker extends ComponentBase {
       return (
         <div
           style={{
-            width: '35%',
+            width: (!dateFormat && this.props.fullWidth) ? '100%' : '35%',
             paddingLeft: 24,
           }}
         >

--- a/packages/components/src/DateTimePicker/dateUtils.js
+++ b/packages/components/src/DateTimePicker/dateUtils.js
@@ -210,9 +210,10 @@ export function getFormatDecomposition(format) {
       timeFormat: undefined,
     };
   }
-  formats.dateFormatHint = Localization.stringLowerCase(
-    Localization.getDateTimeFormat(formats.dateFormat),
-  );
+  if (formats.dateFormat)
+    formats.dateFormatHint = Localization.stringLowerCase(
+      Localization.getDateTimeFormat(formats.dateFormat),
+    );
   if (formats.timeFormat)
     formats.timeFormatHint = Localization.stringLowerCase(
       Localization.getDateTimeFormat(formats.timeFormat),
@@ -220,9 +221,11 @@ export function getFormatDecomposition(format) {
 
   let dateMask = formats.dateFormatHint;
   let timeMask = formats.timeFormatHint;
-  dateMask = dateMask.replaceAll('d', 'n');
-  dateMask = dateMask.replaceAll('m', 'n');
-  dateMask = dateMask.replaceAll('y', 'n');
+  if (dateMask) {
+    dateMask = dateMask.replaceAll('d', 'n');
+    dateMask = dateMask.replaceAll('m', 'n');
+    dateMask = dateMask.replaceAll('y', 'n');
+  }
   if (timeMask) {
     timeMask = timeMask.replaceAll('s', 'n');
     timeMask = timeMask.replaceAll('h', 'n');

--- a/stories/DateTimePicker/doc.json
+++ b/stories/DateTimePicker/doc.json
@@ -316,7 +316,7 @@
 				"name": "bool"
 			},
 			"required": false,
-			"description": "If `false`, width property of the field is assigned 100.",
+			"description": "If `true`, width property of the field is assigned 100.",
 			"defaultValue": {
 				"value": true,
 				"computed": false


### PR DESCRIPTION
Fixed **toString** error only when format property given only time (hmmss).
Fixed **fullWidth** and style.
![Screenshot_1](https://user-images.githubusercontent.com/28100737/56502744-0cd0a200-651c-11e9-9734-e2f835310be6.jpg)
